### PR TITLE
added outlines functionality

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -49,7 +49,10 @@ almost all of the functionalities of this library.
                 "running_sections": ["footer"],
                 "content": [
 
-                    {".": "A Title", "style": "title", "label": "title1"},
+                    {
+                        ".": "A Title", "style": "title", "label": "title1",
+                        "outline": {"level": 1, "text": "A different title 1"}
+                    },
 
                     ["This is a paragraph with a ", {".b": "bold part"}, ", a ",
                     {".": "link", "style": "url", "uri": "https://some.url.com"},
@@ -102,7 +105,10 @@ almost all of the functionalities of this library.
                 "running_sections": ["header", "footer"],
                 "content": [
 
-                    {".": "Title 2", "style": "title", "label": "title2"},
+                    {
+                        ".": "Title 2", "style": "title", "label": "title2",
+                        "outline": {}
+                    },
 
                     ["This is a paragraph with a reference to ",
                     {".": "Title 1.", "style": "url", "ref": "title1"}],

--- a/pdfme/document.py
+++ b/pdfme/document.py
@@ -29,7 +29,13 @@ class PDFDocument:
       with all of the keys that a content box can have (see
       :class:`pdfme.content.PDFContent` for more information about content
       box, and for the default values of the attributes of this dict see
-      :class:`pdfme.pdf.PDF`).
+      :class:`pdfme.pdf.PDF`). Additional to the keys of content box style, you
+      can add the following keys:
+
+      * ``outlines_level``: the level of the outlines to be displayed on the
+        outlines panel of the PDF reader, when the PDF document is opened.
+        For example if this is 2, you will see only the first 2 levels of the
+        outlines. Default value is 1.
 
     * ``page_style``: a dict with the default attributes for each page in this
       document. You can include any of the following keys: ``page_size``,
@@ -163,7 +169,10 @@ class PDFDocument:
             if k in page_style
         }
 
-        self.pdf = PDF(**self.page_args, **style_args)
+        self.pdf = PDF(
+            outlines_level=style.get('outlines_level', 1),
+            **self.page_args, **style_args
+        )
         self.pdf.formats = {}
         self.pdf.formats['$footnote'] = {'r': 0.5, 's': 6}
         self.pdf.formats['$footnotes'] = {'s': 10, 'c': 0}

--- a/pdfme/page.py
+++ b/pdfme/page.py
@@ -36,7 +36,7 @@ class PDFPage:
         self.height = height
         self.go_to_beginning()
 
-        self.stream = base.add({'__stream__': {}})
+        self.stream = base.add({'Filter': b'/FlateDecode', '__stream__': {}})
         self.page = base.add({
             'Type': b'/Page', 'Contents': self.stream.id, 'Resources': {}
         })


### PR DESCRIPTION
# Description
Now it's possible to add outlines to the PDF document (Check Section 12.3.3 Document Outline of PDF 1.7 spec).
You can add an outline in any paragraph, by adding a paragraph part (a dict) with a key `outline`, which value is a dict too, with optional keys `level` and `text`.
Documentation was updated to reflect these changes.