### PR TITLE
deepcopy fix

### DIFF
--- a/pdfme/color.py
+++ b/pdfme/color.py
@@ -1,5 +1,4 @@
 import re
-from copy import deepcopy
 from typing import Union
 
 colors = {
@@ -169,7 +168,7 @@ class PDFColor:
         self, color: Union[ColorType, 'PDFColor'], stroke: bool=False
     ) -> None:
         if isinstance(color, PDFColor):
-            self.color = deepcopy(color.color)
+            self.color = copy(color.color)
         else:
             self.color = parse_color(color)
         self.stroke = stroke
@@ -267,3 +266,5 @@ def parse_color(color: ColorType) -> list:
             return [float(c) for c in color[:4]]
         except:
             raise TypeError("Couldn't parse numeric color value: {}".format(color))
+
+from .utils import copy

--- a/pdfme/content.py
+++ b/pdfme/content.py
@@ -777,6 +777,7 @@ class PDFContentPart:
             pdf_text = element['paragraph']
             pdf_text.setup(self.x, self.y, self.width, self.max_height)
             pdf_text.set_state(**element['state'])
+            pdf_text.finished = False
             remaining = copy(element)
         else:
             par_style = {
@@ -858,6 +859,7 @@ class PDFContentPart:
             pdf_table = element['table_delayed']
             pdf_table.setup(self.x, self.y, self.width, self.max_height)
             pdf_table.set_state(**element['state'])
+            pdf_table.finished = False
             remaining = copy(element)
         else:
             table_props = {
@@ -921,13 +923,14 @@ class PDFContentPart:
 
         action = pdf_content.run()
 
-        current_height = pdf_content.min_y - (
-            pdf_content.max_y if pdf_content.cols_n > 1 else pdf_content.y
-        )
-        self.y -= current_height
+        if action != 'partial_next':
+            current_height = pdf_content.min_y - (
+                pdf_content.max_y if pdf_content.cols_n > 1 else pdf_content.y
+            )
+            self.y -= current_height
 
-        if current_height > 0:
-            self.add_top_margin(style)
+            if current_height > 0:
+                self.add_top_margin(style)
 
         if action in ['interrupt', 'break', 'partial_next']:
             return action

--- a/pdfme/content.py
+++ b/pdfme/content.py
@@ -232,12 +232,33 @@ class PDFContent:
             self.finished = True
 
     def get_state(self) -> dict:
+        """Method to get the current state of this content box. This can be used
+        later in method :meth:`pdfme.content.PDFContent.set_state` to restore
+        this state in this content box (like a checkpoint in a videogame).
+
+        Returns:
+            dict: a dict with the state of this content box.
+        """
         return self.pdf_content_part.get_state()
 
     def set_state(
         self, section_element_index: int=None, section_delayed: list=None,
         children_memory: list=None
     ) -> None:
+        """Method to set the state of this content box.
+        
+        The 3 arguments of this method define the current state of this content
+        box, and with this method you can change that state.
+
+        Args:
+            section_element_index (int, optional): the index of the current
+                element being added.
+            section_delayed (list, optional): a list of delayed elements, that
+                should be added before continuing with the rest of elements.
+            children_memory (list, optional): if the current element is in turn
+                a content box, this list says what the indexes of the nested
+                content boxes inside this content box are.
+        """
         self.pdf_content_part.set_state(
             section_element_index, section_delayed, children_memory
         )
@@ -347,6 +368,14 @@ class PDFContentPart:
         self.minim_forward = None
 
     def get_state(self) -> dict:
+        """Method to get the current state of this content box. This can be used
+        later in method :meth:`pdfme.content.PDFContentPart.set_state` to
+        restore this state in this content box (like a checkpoint in a
+        videogame).
+
+        Returns:
+            dict: a dict with the state of this content box.
+        """
         return {
             'section_element_index': self.section_element_index,
             'section_delayed': copy(self.section_delayed),
@@ -357,6 +386,20 @@ class PDFContentPart:
         self, section_element_index: int=None, section_delayed: list=None,
         children_memory: list=None
     ) -> None:
+        """Method to set the state of this content box part.
+        
+        The arguments of this method define the current state of this content
+        box part, and with this method you can change that state.
+
+        Args:
+            section_element_index (int, optional): the index of the current
+                element being added.
+            section_delayed (list, optional): a list of delayed elements, that
+                should be added before continuing with the rest of elements.
+            children_memory (list, optional): if the current element is in turn
+                a content box, this list says what the indexes of the nested
+                content boxes inside this content box are.
+        """
         self.section_element_index = section_element_index
         self.section_delayed = copy(section_delayed)
         self.children_memory = copy(children_memory)

--- a/pdfme/pdf.py
+++ b/pdfme/pdf.py
@@ -1,4 +1,3 @@
-import copy
 import json
 from io import BytesIO
 from pathlib import Path
@@ -265,7 +264,7 @@ class PDF:
         if (rotate_page is None and self.rotate_page) or rotate_page:
             page_height, page_width = page_width, page_height
 
-        margin_ = copy.deepcopy(self.margin)
+        margin_ = copy(self.margin)
         if margin is not None:
             margin_.update(parse_margin(margin))
 
@@ -1081,6 +1080,6 @@ from .parser import PDFObject
 from .table import PDFTable
 from .text import PDFText
 from .utils import (
-    create_graphics, get_page_size, get_paragraph_stream,
-    parse_margin, parse_style_str, process_style, to_roman
+    create_graphics, get_page_size, get_paragraph_stream, parse_margin,
+    parse_style_str, process_style, to_roman, copy
 )

--- a/pdfme/table.py
+++ b/pdfme/table.py
@@ -833,6 +833,7 @@ class PDFTable:
             pdf_text = element['delayed']
             pdf_text.setup(x, y, width, height)
             pdf_text.set_state(**element['state'])
+            pdf_text.finished = False
         else:
             par_style = {
                 v: style.get(v) for v in PARAGRAPH_PROPS if v in style
@@ -916,6 +917,7 @@ class PDFTable:
             pdf_content = element['delayed']
             pdf_content.setup(x, y, width, height)
             pdf_content.set_state(**element['state'])
+            pdf_content.finished = False
         else:
             element['style'] = style
             pdf_content = PDFContent(
@@ -957,6 +959,7 @@ class PDFTable:
             pdf_table = element['delayed']
             pdf_table.setup(x, y, width, height)
             pdf_table.set_state(**element['state'])
+            pdf_table.finished = False
         else:
             table_props = {
                 v: element.get(v) for v in TABLE_PROPS if v in element

--- a/pdfme/table.py
+++ b/pdfme/table.py
@@ -218,21 +218,35 @@ class PDFTable:
         if height is not None:
             self.height = height
 
-    def get_state(self):
+    def get_state(self) -> dict:
+        """Method to get the current state of this table. This can be used
+        later in method :meth:`pdfme.table.PDFTable.set_state` to
+        restore this state in this table (like a checkpoint in a
+        videogame).
+
+        Returns:
+            dict: a dict with the state of this table.
+        """
         return {
             'current_index': self.current_index, 'delayed': copy(self.delayed)
         }
 
     def set_state(self, current_index: int=None, delayed: dict=None) -> None:
-        """Function to update the state of the paragraph
+        """Method to set the state of this table.
+        
+        The arguments of this method define the current state of this table,
+        and with this method you can change that state.
 
         Args:
-            current_index (int): this is the index of the row to be added
-                the next time you call method ``run``.
-            delayed (dict): 
+            current_index (int, optional): the index of the current row being
+                added.
+            delayed (dict, optional): a dict with delayed cells that should be
+                added before the next row.
         """
-        self.current_index = current_index
-        self.delayed = delayed
+        if current_index is not None:
+            self.current_index = current_index
+        elif delayed is not None:
+            self.delayed = delayed
 
     def set_default_border(self) -> None:
         """Method to create attribute ``default_border`` containing the default

--- a/pdfme/table.py
+++ b/pdfme/table.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from typing import Iterable, Optional, Union
 
 PARAGRAPH_PROPS = (
@@ -219,6 +218,22 @@ class PDFTable:
         if height is not None:
             self.height = height
 
+    def get_state(self):
+        return {
+            'current_index': self.current_index, 'delayed': copy(self.delayed)
+        }
+
+    def set_state(self, current_index: int=None, delayed: dict=None) -> None:
+        """Function to update the state of the paragraph
+
+        Args:
+            current_index (int): this is the index of the row to be added
+                the next time you call method ``run``.
+            delayed (dict): 
+        """
+        self.current_index = current_index
+        self.delayed = delayed
+
     def set_default_border(self) -> None:
         """Method to create attribute ``default_border`` containing the default
         border values.
@@ -298,7 +313,7 @@ class PDFTable:
         self.borders_h = {}
         self.borders_v = {}
         for b in borders:
-            border = deepcopy(deepcopy(self.default_border))
+            border = copy(self.default_border)
             border.update(b)
             border['color'] = PDFColor(border['color'], True)
             pos = border.pop('pos', None)
@@ -325,9 +340,9 @@ class PDFTable:
         """
         border_l = self.borders_v if is_vert else self.borders_h
         if i in border_l and j in border_l[i]:
-            return deepcopy(border_l[i][j])
+            return copy(border_l[i][j])
         else:
-            return deepcopy(self.default_border)
+            return copy(self.default_border)
 
     def setup_fills(self, fills: Iterable) -> None:
         """Method to process the ``fills`` argument passed to this class, and
@@ -653,7 +668,7 @@ class PDFTable:
             cell_style = element['cell_style']
             style = {}
         else:
-            style = deepcopy(self.style)
+            style = copy(self.style)
 
             if element is None:
                 element = ''
@@ -680,7 +695,7 @@ class PDFTable:
                 )
             style.pop(attr, None)
             cell_style['cell_fill'] = style.pop('cell_fill', None)
-        element = deepcopy(element)
+        element = copy(element)
         return element, style, cell_style
 
     def _setup_cell_fill(
@@ -761,23 +776,29 @@ class PDFTable:
         keys = [key for key in element.keys() if key.startswith('.')]
 
         real_height = 0
+        did_finished = False
         if len(keys) > 0 or self._is_delayed_type(element, 'text'):
-            real_height = self.process_text(
-                col, element, x, y, width, height, style, delayed
+            real_height, did_finished = self.process_text(
+                element, x, y, width, height, style, delayed
             )
         elif self.is_type(element, 'image'):
-            real_height = self.process_image(
-                col, element, x, y, width, height, delayed
+            real_height, did_finished = self.process_image(
+                element, x, y, width, height, delayed
             )
         elif self.is_type(element, 'content'):
-            real_height = self.process_content(
-                col, element, x, y, width, height, style, delayed
+            real_height, did_finished = self.process_content(
+                element, x, y, width, height, style, delayed
             )
 
         elif self.is_type(element, 'table'):
-            real_height = self.process_table(
-                col, element, x, y, width, height, style, delayed
+            real_height, did_finished = self.process_table(
+                element, x, y, width, height, style, delayed
             )
+
+        if did_finished:
+            self.delayed.pop(col, None)
+        else:
+            self.delayed[col] = delayed
 
         real_height += padd_y if real_height>0 else (0 if self.first_row else 4)
         if rowspan > 0:
@@ -789,7 +810,7 @@ class PDFTable:
         return False
 
     def process_text(
-        self, col: int, element: dict, x: Number, y: Number, width: Number,
+        self, element: dict, x: Number, y: Number, width: Number,
         height: Number, style: dict, delayed: dict
     ) -> float:
         """Method to add a paragraph to a cell.
@@ -811,7 +832,7 @@ class PDFTable:
         if 'delayed' in element:
             pdf_text = element['delayed']
             pdf_text.setup(x, y, width, height)
-            pdf_text.pdf = self.pdf
+            pdf_text.set_state(**element['state'])
         else:
             par_style = {
                 v: style.get(v) for v in PARAGRAPH_PROPS if v in style
@@ -828,13 +849,11 @@ class PDFTable:
 
         if not pdf_text.finished:
             delayed.update({'delayed': pdf_text, 'type': 'text'})
-            self.delayed[col] = delayed
-        else:
-            self.delayed.pop(col, None)
-        return pdf_text.current_height
+            delayed['state'] = pdf_text.get_state()
+        return pdf_text.current_height, pdf_text.finished
 
     def process_image(
-        self, col: int, element: dict, x: Number, y: Number,
+        self, element: dict, x: Number, y: Number, 
         width: Number, height: Number, delayed: dict
     ) -> float:
         """Method to add an image to a cell.
@@ -860,6 +879,7 @@ class PDFTable:
         img_height = img_width * pdf_image.height / pdf_image.width
 
         real_height = 0
+        finished = False
         if img_height < height:
             real_height = img_height
             self.parts.append({
@@ -867,14 +887,13 @@ class PDFTable:
                 'x': x, 'y': y - img_height,
                 'width': img_width, 'height': img_height
             })
-            self.delayed.pop(col, None)
+            finished = True
         else:
             delayed.update({'delayed': pdf_image, 'type': 'image'})
-            self.delayed[col] = delayed
-        return real_height
+        return real_height, finished
 
     def process_content(
-        self, col: int, element: dict, x: Number, y: Number,
+        self, element: dict, x: Number, y: Number,
         width: Number, height: Number, style: dict, delayed: dict
     ) -> float:
         """Method to add a content box to a cell.
@@ -896,7 +915,7 @@ class PDFTable:
         if 'delayed' in element and element['type'] == 'content':
             pdf_content = element['delayed']
             pdf_content.setup(x, y, width, height)
-            pdf_content.pdf = self.pdf
+            pdf_content.set_state(**element['state'])
         else:
             element['style'] = style
             pdf_content = PDFContent(
@@ -911,14 +930,11 @@ class PDFTable:
 
         if not pdf_content.finished:
             delayed.update({'delayed': pdf_content, 'type': 'content'})
-            self.delayed[col] = delayed
-        else:
-            self.delayed.pop(col, None)
-
-        return pdf_content.current_height
+            delayed['state'] = pdf_content.get_state()
+        return pdf_content.current_height, pdf_content.finished
 
     def process_table(
-        self, col: int, element: dict, x: Number, y: Number,
+        self, element: dict, x: Number, y: Number,
         width: Number, height: Number, style: dict, delayed: dict
     ) -> float:
         """Method to add a table to a cell.
@@ -940,7 +956,7 @@ class PDFTable:
         if 'delayed' in element and element['type'] == 'table':
             pdf_table = element['delayed']
             pdf_table.setup(x, y, width, height)
-            pdf_table.pdf = self.pdf
+            pdf_table.set_state(**element['state'])
         else:
             table_props = {
                 v: element.get(v) for v in TABLE_PROPS if v in element
@@ -958,11 +974,8 @@ class PDFTable:
 
         if not pdf_table.finished:
             delayed.update({'delayed': pdf_table, 'type': 'table'})
-            self.delayed[col] = delayed
-        else:
-            self.delayed.pop(col, None)
-
-        return pdf_table.current_height
+            delayed['state'] = pdf_table.get_state()
+        return pdf_table.current_height, pdf_table.finished
 
 from .color import PDFColor
 from .content import PDFContent
@@ -970,4 +983,4 @@ from .fonts import PDFFonts
 from .image import PDFImage
 from .pdf import PDF
 from .text import PDFText
-from .utils import parse_style_str, process_style
+from .utils import parse_style_str, process_style, copy

--- a/pdfme/text.py
+++ b/pdfme/text.py
@@ -520,6 +520,14 @@ class PDFTextBase:
         )
 
     def get_state(self) -> dict:
+        """Method to get the current state of this paragraph. This can be used
+        later in method :meth:`pdfme.text.PDFText.set_state` to
+        restore this state in this paragraph (like a checkpoint in a
+        videogame).
+
+        Returns:
+            dict: a dict with the state of this paragraph.
+        """
         return {
             'last_part': self.last_part,
             'last_word': self.last_word
@@ -527,6 +535,9 @@ class PDFTextBase:
 
     def set_state(self, last_part: int=None, last_word: int=None) -> None:
         """Function to update the state of the paragraph
+
+        The arguments of this method define the current state of this paragraph,
+        and with this method you can change that state.
 
         Args:
             last_part (int): this is the index of the part that was being

--- a/pdfme/text.py
+++ b/pdfme/text.py
@@ -1,6 +1,5 @@
 import json
 import re
-from copy import deepcopy
 from typing import Optional, Union
 from uuid import uuid4
 
@@ -520,9 +519,28 @@ class PDFTextBase:
             used_fonts=self.used_fonts, ids=self.ids,
         )
 
+    def get_state(self) -> dict:
+        return {
+            'last_part': self.last_part,
+            'last_word': self.last_word
+        }
+
+    def set_state(self, last_part: int=None, last_word: int=None) -> None:
+        """Function to update the state of the paragraph
+
+        Args:
+            last_part (int): this is the index of the part that was being
+                processed the last time method ``run`` was called.
+            last_word (int): this is the index of the
+                word of the last part that was added the last time method
+                ``run`` was called.
+        """
+        self.last_part = last_part
+        self.last_word = last_word
+
     def setup(
         self, x: Number=None, y:Number=None, width: Number=None,
-        height: Number=None, last_part: int=None, last_word: int=None
+        height: Number=None
     ):
         """Function to change any or all of the parameters of the rectangle of
         the content.
@@ -551,10 +569,6 @@ class PDFTextBase:
             self.width = width
         if height is not None:
             self.height = height
-        if last_part is not None:
-            self.last_part = last_part
-        if last_word is not None:
-            self.last_word = last_word
 
     def init(self) -> None:
         """Function to reset all of the instance properties that have to be
@@ -587,7 +601,7 @@ class PDFTextBase:
 
     def run(
         self, x: Number=None, y: Number=None, width: Number=None,
-        height: Number=None, last_part: Number=None, last_word: Number=None
+        height: Number=None
     ) -> dict:
         """Function to create the data needed to add this paragraph to the PDF
         document.
@@ -602,7 +616,7 @@ class PDFTextBase:
         Returns:
             dict: The dict from the property ``result``.
         """
-        self.setup(x, y, width, height, last_part, last_word)
+        self.setup(x, y, width, height)
         self.init()
         for part_index in range(self.last_part, len(self.content)):
             part = self.content[part_index]
@@ -1196,8 +1210,8 @@ class PDFText(PDFTextBase):
             TypeError: If the content part passed doesn't have the format
                 described in the documentation of this class.
         """
-        style = deepcopy(parent_style)
-        ids = deepcopy(ids)
+        style = parent_style.copy()
+        ids = ids.copy()
 
         if isinstance(content, str):
             content = {'.': [content]}
@@ -1286,4 +1300,4 @@ class PDFText(PDFTextBase):
 from .color import PDFColor
 from .fonts import PDFFonts
 from .pdf import PDF
-from .utils import get_paragraph_stream, parse_style_str, process_style
+from .utils import get_paragraph_stream, parse_style_str, process_style, copy

--- a/pdfme/utils.py
+++ b/pdfme/utils.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 import re
 from typing import Iterable, Union
 
@@ -46,7 +45,7 @@ def process_style(style: Union[str, dict], pdf: 'PDF'=None) -> dict:
     elif isinstance(style, str):
         if pdf is None:
             return {}
-        return deepcopy(pdf.formats[style])
+        return copy(pdf.formats[style])
     elif isinstance(style, dict):
         return style
     else:
@@ -352,6 +351,14 @@ def get_paragraph_stream(
     if text_stream != '':
         stream += ' BT 1 0 0 1 {} {} Tm{} ET'.format(x, y, text_stream)
     return stream
+
+def copy(obj):
+    if isinstance(obj, list):
+        return [copy(el) for el in obj]
+    elif isinstance(obj, dict):
+        return {k: copy(v) for k, v in obj.items()}
+    else:
+        return obj
 
 from .color import PDFColor
 from .fonts import PDFFonts

--- a/pdfme/utils.py
+++ b/pdfme/utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable, Union
+from typing import Any, Iterable, Union
 
 page_sizes = {
     'a5': (419.528, 595.276),
@@ -352,7 +352,17 @@ def get_paragraph_stream(
         stream += ' BT 1 0 0 1 {} {} Tm{} ET'.format(x, y, text_stream)
     return stream
 
-def copy(obj):
+def copy(obj: Any) -> Any:
+    """Function to copy objects like the ones used in this project: dicts,
+    lists, PDFText, PDFTable, PDFContent, etc.
+
+
+    Args:
+        obj (Any): the object to be copied.
+
+    Returns:
+        Any: the copy of the object passed as argument.
+    """
     if isinstance(obj, list):
         return [copy(el) for el in obj]
     elif isinstance(obj, dict):


### PR DESCRIPTION
# Description
Using deepcopy in content module was slowing it down, specially when a lot of multicolumn nested elements were being added into a content box. An alternative for deepcopy was created, and some modifications were made in the rest of the code to replace deepcopy with our alternative. Some simple time measurements were made and this fix has improved the speed of content module  8 to 10 times.