### PR TITLE
changed finished property of section's content box in document module

### DIFF
--- a/pdfme/document.py
+++ b/pdfme/document.py
@@ -341,6 +341,7 @@ class PDFDocument:
 
             if section_state is not None:
                 self.section.set_state(**section_state)
+                self.section.finished = False
             self.pdf._content(self.section, height=new_height)
 
             footnotes_obj = self._process_footnotes()


### PR DESCRIPTION
# Description
Fix issue #5. Changed `finished` property of section's content box in `document` module after adding footnotes and running section again, because sometimes this property is `true` after the first run.