### PR TITLE
fixed error with borders in combined cells in table

### DIFF
--- a/pdfme/table.py
+++ b/pdfme/table.py
@@ -664,6 +664,8 @@ class PDFTable:
                     self.fills_mem[col]['add_later'] = False
                 if self.heights_mem.get(col, 0) > self.max_height:
                     self.max_height = self.heights_mem[col]
+                if self.colspan == 0:
+                    self.is_rowspan = False
             can_continue = True
         return can_continue
 


### PR DESCRIPTION
# Description
PR to fix #7. Fixed error with borders in combined cells in table, by setting attribute `is_rowspan` to `False`  when attribute `colspan` is zero, on `table` module