### PR TITLE
Fixed "is" literal comparison warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Add possibility of embedding ttf and unicode fonts.
 
+## [0.4.12] - 2025-02-13
+### Fixed
+- Fixed error when using empty string as color.
+
 ## [0.4.11] - 2022-04-05
 ### Fixed
 - Fixed error when using in-memory images.

--- a/pdfme/color.py
+++ b/pdfme/color.py
@@ -230,7 +230,7 @@ def parse_color(color: ColorType) -> list:
     if isinstance(color, (int, float)):
         return [color]
     if isinstance(color, str):
-        if color is '':
+        if color == '':
             return None
         elif color in colors:
             return colors[color]


### PR DESCRIPTION
Addresses #34 

## Changes
* Swapped `is` for `==`
* Bumped patch number in changelog.

## Tests
`$ python test.py` ✅ 